### PR TITLE
LRIS-34331

### DIFF
--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liferay-zendesk-theme",
-  "version": "1.3.2",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/theme/src/css/_zendesk-search.scss
+++ b/theme/src/css/_zendesk-search.scss
@@ -9,8 +9,12 @@
 	}
 
 	.no-results {
-		display: flex;
+		display: none;
 		margin-bottom: 10rem;
+
+		&.show {
+			display: flex;
+		}
 
 		.no-results-msg {
 			padding-left: $padding-default;

--- a/theme/src/js/components/SearchResults.js
+++ b/theme/src/js/components/SearchResults.js
@@ -1,0 +1,190 @@
+import preact from 'preact';
+import PropTypes from 'prop-types';
+
+import {getArticlesBySearchQuery, getSectionBySectionId} from '../helpers/api-helpers';
+
+import LoadingIndicator from './LoadingIndicator';
+
+class SearchResultBreadCrumb extends preact.Component {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			breadcrumb: [],
+			loading: true
+		}
+	}
+
+	componentDidMount() {
+		const {id, locale} = this.props;
+
+		getSectionBySectionId(id, locale, 'categories')
+			.then(
+				({data}) => {
+					const breadcrumbData = [
+						{
+							name: data.categories[0].name,
+							url: data.categories[0].html_url
+						},
+						{
+							name: data.section.name,
+							url: data.section.html_url
+						}
+					]
+
+					this.setState(
+						{
+							loading: false,
+							breadcrumb: breadcrumbData
+						}
+					)
+				}
+			)
+			.catch(
+				(err) => {
+					this.setState(
+						{
+							loading: false
+						}
+					);
+
+					if (process.env.NODE_ENV === 'development') {
+						console.log(err);
+					}
+				}
+			);
+	}
+
+	render() {
+		const {loading, breadcrumb} = this.state;
+
+		return (
+			<div>
+				{!loading && breadcrumb.length && (
+					<ol class="breadcrumbs">
+						{breadcrumb.map(
+							(data, index) => (
+								<li key={index} title={data.name}>
+									<a href={data.url}>{data.name}</a>
+								</li>
+							)
+						)}
+					</ol>
+				)}
+
+				{loading && <LoadingIndicator />}
+			</div>
+		)
+	}
+}
+
+SearchResultBreadCrumb.PropTypes = {
+	id: PropTypes.string.isRequired,
+	locale: PropTypes.string.isRequired
+};
+
+class SearchResults extends preact.Component {
+	constructor(props) {
+		super(props);
+
+		this.showNoResultsMsg = this.showNoResultsMsg.bind(this);
+
+		this.state = {
+			loading: true,
+			results: []
+		}
+	}
+
+	componentDidMount() {
+		const {queryString} = this.props;
+
+		if (queryString) {
+			getArticlesBySearchQuery(queryString)
+			.then(
+				({data}) => {
+					if (!data.results.length) {
+						this.showNoResultsMsg();
+					}
+
+					this.setState(
+						{
+							loading: false,
+							results: data.results
+						}
+					)
+				}
+			)
+			.catch(
+				(err) => {
+					this.showNoResultsMsg();
+
+					this.setState(
+						{
+							loading: false
+						}
+					)
+
+					if (process.env.NODE_ENV === 'development') {
+						console.log(err);
+					}
+				}
+			);
+		} else {
+			this.showNoResultsMsg();
+
+			this.setState(
+				{
+					loading: false
+				}
+			)
+		}
+	}
+
+	showNoResultsMsg() {
+		const noResults = document.getElementById(
+			'noResults'
+		);
+
+		noResults.classList.add('show');
+	}
+
+	render() {
+		const {loading, results} = this.state;
+
+		return (
+			<div>
+				{!loading && !!results.length && (
+					<ul class="search-results-list">
+						{results.map(
+							(result, index) => (
+								<li key={index} class="search-result">
+									<a class="search-result-link" href={result.html_url}>{result.title}</a>
+
+									<h5
+										class="search-result-description"
+										dangerouslySetInnerHTML={{
+											__html: result.snippet
+										}}
+									/>
+
+									<SearchResultBreadCrumb
+										id={result.section_id}
+										locale={result.locale}
+									/>
+								</li>
+							)
+						)}
+					</ul>
+				)}
+
+				{loading && <LoadingIndicator />}
+			</div>
+		)
+	}
+}
+
+SearchResults.PropTypes = {
+	queryString: PropTypes.string.isRequired
+};
+
+export default SearchResults;

--- a/theme/src/js/components/__tests__/SearchResults.js
+++ b/theme/src/js/components/__tests__/SearchResults.js
@@ -1,0 +1,14 @@
+import preact from 'preact';
+import render from 'preact-render-to-string';
+
+import SearchResults from '../SearchResults';
+
+describe('SearchResults', () => {
+	it('renders correctly', () => {
+		const tree = render(
+			<SearchResults queryString="Test" />
+		);
+
+		expect(tree).toMatchSnapshot();
+	});
+});

--- a/theme/src/js/components/__tests__/__snapshots__/SearchResults.js.snap
+++ b/theme/src/js/components/__tests__/__snapshots__/SearchResults.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchResults renders correctly 1`] = `
+<div>
+  <span aria-hidden="true" class="loading-animation loading-animation-sm"></span>
+</div>
+`;

--- a/theme/src/js/helpers/api-helpers.js
+++ b/theme/src/js/helpers/api-helpers.js
@@ -47,10 +47,13 @@ export function getRequestById(id) {
  * Returns a promise of the Section object
  * @param {string} id The section id
  * @param {string} locale The user's current locale
+ * @param {string} resourceNames The comma separated name(s) of the resource to be side loaded within the Promise object
  * @returns {Promise} Promise object of a section by its id
  */
-export function getSectionBySectionId(id, locale) {
-	return httpRequest.get(`help_center/${locale}/sections/${id}.json`);
+export function getSectionBySectionId(id, locale, resourceNames = '') {
+	return httpRequest.get(
+		`help_center/${locale}/sections/${id}.json?include=${resourceNames}`
+	);
 }
 
 /**

--- a/theme/src/js/helpers/api-helpers.js
+++ b/theme/src/js/helpers/api-helpers.js
@@ -9,6 +9,17 @@ const httpRequest = axios.create(
 );
 
 /**
+ * Returns a promise of Articles that matches the query string
+ * @param {string} queryString The query string
+ * @returns {Promise} Promise object of 10 Articles per page that matches the query string
+ */
+export function getArticlesBySearchQuery(queryString) {
+	return httpRequest.get(
+		`help_center/articles/search.json?query=${queryString}&per_page=10`
+	);
+}
+
+/**
  * Returns a promise of Articles under a Section
  * @param {string} id The section id
  * @param {string} locale The user's current locale

--- a/theme/src/js/index.js
+++ b/theme/src/js/index.js
@@ -22,3 +22,4 @@ export {default as Alert} from './components/Alert';
 export {default as CallToAction} from './components/CallToAction';
 export {default as DocSideNav} from './components/DocSideNav';
 export {default as ProductTabs} from './components/ProductTabs';
+export {default as SearchResults} from './components/SearchResults';

--- a/theme/src/resources/templates/search_results.hbs
+++ b/theme/src/resources/templates/search_results.hbs
@@ -21,43 +21,33 @@
 		</header>
 
 		<section>
-			{{#if article_results}}
-				<ul class="search-results-list">
-					{{#each article_results}}
-						<li class="search-result">
-							<a class="search-result-link" href="{{url}}">{{title}}</a>
+			<div id="searchResultsBody"></div>
 
-							<h5 class="search-result-description">
-								{{text}}
-							</h5>
+			<div class="no-results" id="noResults">
+				<img alt="{{t 'oops'}}" class="img" src="{{asset 'telescope_scene.svg'}}" />
 
-							<ol class="breadcrumbs">
-								{{#each path_steps}}
-									<li title="{{name}}">
-										<a href="{{url}}">{{name}}</a>
-									</li>
-								{{/each}}
-							</ol>
-						</li>
-					{{/each}}
-				</ul>
-			{{else}}
-				<div class="no-results">
-					<img alt="{{t 'oops'}}" class="img" src="{{asset 'telescope_scene.svg'}}" />
+				<div class="no-results-msg">
+					<h4>
+						{{dc 'sorry_we_searched_far_into_outer_space_but_couldnt_find'}} "{{query}}"
+					</h4>
 
-					<div class="no-results-msg">
-						<h4>
-							{{dc 'sorry_we_searched_far_into_outer_space_but_couldnt_find'}} "{{query}}"
-						</h4>
-
-						{{#link 'help_center' class="secondary-font"}}
-							{{t 'browse_knowledge_base'}}
-						{{/link}}
-					</div>
+					{{#link 'help_center' class="secondary-font"}}
+						{{t 'browse_knowledge_base'}}
+					{{/link}}
 				</div>
-			{{/if}}
+			</div>
 		</section>
 
 		{{pagination}}
 	</div>
 </div>
+
+<script>
+	Liferay.render(
+		Liferay.SearchResults,
+		{
+			queryString: '{{query}}'
+		},
+		document.getElementById('searchResultsBody')
+	);
+</script>

--- a/theme/webpack.common.js
+++ b/theme/webpack.common.js
@@ -104,6 +104,7 @@ module.exports = {
 					'products-landing-tablist',
 					'*request_description_hint*',
 					'*search-result-description*',
+					'*search-results-list*',
 					'sidenav-fallback',
 					'sidenav-tree',
 					'status-label-answered',


### PR DESCRIPTION
### Description
https://issues.liferay.com/browse/LRIS-34331

This is the first of the Help Center [search filter tickets](https://issues.liferay.com/browse/LRIS-31533). Motivation behind this series of tickets is that the official docs have articles with the same title for different products. When these article names show up on search results, it's confusing to the user as they appear to be the same result repeated many times. So the solution was to give the user an option to use a search filter that will narrow the results by products.  

Zendesk allows a `label_name` parameter to be added to the search API call to reduce the search results. However it is only viable through an API call, not by adding the parameter in the url on the search page. As a result, recreate the search results page through javascript is the only option. This current ticket recreates the said results list. There will be follow up tickets to add the pagination and the search filter. 

One thing to note is that in order to generate the breadcrumb like links beneath each search result, an additional API call had to be made per each result displayed. This could pose a performance issue. Cole will evaluate after the feature is on sandbox.

I will add more tests as I work on the series of the tickets. Let me know if you have any questions, thanks!

### Checklist
- [x] Code compiles without errors.
- [x] All tests, new and existing, pass without errors.
- [x] Appropriate documentation.